### PR TITLE
enable "make install" on Haiku

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ clean:
 
 
 #------------------------------------------------------------------------
-#make install is validated only for Linux, OSX, kFreeBSD, Hurd and
+#make install is validated only for Linux, OSX, kFreeBSD, Hurd, Haiku and
 #FreeBSD targets
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD))
+ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD Haiku))
 HOST_OS = POSIX
 
 install:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -101,9 +101,9 @@ clean:
 
 
 #------------------------------------------------------------------------
-#make install is validated only for Linux, OSX, kFreeBSD, Hurd and
+#make install is validated only for Linux, OSX, kFreeBSD, Hurd, Haiku and
 #FreeBSD targets
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD))
+ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD Haiku))
 
 liblz5.pc: liblz5.pc.in Makefile
 	@echo creating pkgconfig

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -98,9 +98,9 @@ clean:
 
 
 #------------------------------------------------------------------------
-#make install is validated only for Linux, OSX, kFreeBSD, Hurd and
+#make install is validated only for Linux, OSX, kFreeBSD, Hurd, Haiku and
 #FreeBSD targets
-ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU FreeBSD MSYS%, $(shell uname)))
+ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU FreeBSD Haiku MSYS%, $(shell uname)))
 
 install: lz5$(EXT)
 	@echo Installing binaries

--- a/programs/util.h
+++ b/programs/util.h
@@ -33,6 +33,7 @@ extern "C" {
 #include <stdlib.h>       /* malloc */
 #include <stddef.h>       /* size_t, ptrdiff_t */
 #include <stdio.h>        /* fprintf */
+#include <string.h>       /* strlen, strncpy */
 #include <sys/types.h>    /* stat, utime */
 #include <sys/stat.h>     /* stat */
 #if defined(_MSC_VER)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -128,9 +128,9 @@ versionsTest:
 
 
 #------------------------------------------------------------------------
-#make install is validated only for Linux, OSX, kFreeBSD, Hurd and
+#make install is validated only for Linux, OSX, kFreeBSD, Hurd, Haiku and
 #FreeBSD targets
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD))
+ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD Haiku))
 
 test: test-lz5 test-lz5c test-frametest test-fullbench test-fuzzer
 


### PR DESCRIPTION
Please consider these patchs:
* enable install target on Haiku
* fixes warnings in util.h (missing prototype for strlen and strncpy)