### PR TITLE
Fix fallthrough warning in gcc

### DIFF
--- a/lib/lizard_frame.c
+++ b/lib/lizard_frame.c
@@ -960,7 +960,8 @@ static void LizardF_updateDict(LizardF_dctx_t* dctxPtr, const BYTE* dstPtr, size
 
 
 /* Define a symbol for avoiding fall-through warnings emitted by gcc >= 7.0 */
-#if ((defined(__GNUC__) && BLOSC_GCC_VERSION >= 700) && !defined(__clang__))
+#define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#if ((defined(__GNUC__) && GCC_VERSION >= 700) && !defined(__clang__))
 #define AVOID_FALLTHROUGH_WARNING
 #endif
 
@@ -1027,7 +1028,7 @@ size_t LizardF_decompress(LizardF_decompressionContext_t decompressionContext,
             dctxPtr->tmpInTarget = minFHSize;   /* minimum to attempt decode */
             dctxPtr->dStage = dstage_storeHeader;
             #ifdef AVOID_FALLTHROUGH_WARNING
-                __attribute__ ((fallthrough));  /* shut-up -Wimplicit-fallthrough warning in GCC */
+            __attribute__ ((fallthrough));  /* shut-up -Wimplicit-fallthrough warning in GCC */
             #endif
 
         case dstage_storeHeader:

--- a/lib/lizard_frame.c
+++ b/lib/lizard_frame.c
@@ -1022,7 +1022,9 @@ size_t LizardF_decompress(LizardF_decompressionContext_t decompressionContext,
             dctxPtr->tmpInSize = 0;
             dctxPtr->tmpInTarget = minFHSize;   /* minimum to attempt decode */
             dctxPtr->dStage = dstage_storeHeader;
-            /* pass-through */
+            #if defined(__GNUC__) && !defined(__clang__)
+                __attribute__ ((fallthrough));  /* shut-up -Wimplicit-fallthrough warning in GCC */
+            #endif
 
         case dstage_storeHeader:
             {   size_t sizeToCopy = dctxPtr->tmpInTarget - dctxPtr->tmpInSize;
@@ -1135,7 +1137,9 @@ size_t LizardF_decompress(LizardF_decompressionContext_t decompressionContext,
                 }
                 selectedIn = dctxPtr->tmpIn;
                 dctxPtr->dStage = dstage_decodeCBlock;
-                /* pass-through */
+                #if defined(__GNUC__) && !defined(__clang__)
+                __attribute__ ((fallthrough));  /* shut-up -Wimplicit-fallthrough warning in GCC */
+                #endif
             }
 
         case dstage_decodeCBlock:

--- a/lib/lizard_frame.c
+++ b/lib/lizard_frame.c
@@ -959,6 +959,10 @@ static void LizardF_updateDict(LizardF_dctx_t* dctxPtr, const BYTE* dstPtr, size
 }
 
 
+/* Define a symbol for avoiding fall-through warnings emitted by gcc >= 7.0 */
+#if ((defined(__GNUC__) && BLOSC_GCC_VERSION >= 700) && !defined(__clang__))
+#define AVOID_FALLTHROUGH_WARNING
+#endif
 
 /*! LizardF_decompress() :
 * Call this function repetitively to regenerate data compressed within srcBuffer.
@@ -1022,7 +1026,7 @@ size_t LizardF_decompress(LizardF_decompressionContext_t decompressionContext,
             dctxPtr->tmpInSize = 0;
             dctxPtr->tmpInTarget = minFHSize;   /* minimum to attempt decode */
             dctxPtr->dStage = dstage_storeHeader;
-            #if defined(__GNUC__) && !defined(__clang__)
+            #ifdef AVOID_FALLTHROUGH_WARNING
                 __attribute__ ((fallthrough));  /* shut-up -Wimplicit-fallthrough warning in GCC */
             #endif
 
@@ -1137,7 +1141,7 @@ size_t LizardF_decompress(LizardF_decompressionContext_t decompressionContext,
                 }
                 selectedIn = dctxPtr->tmpIn;
                 dctxPtr->dStage = dstage_decodeCBlock;
-                #if defined(__GNUC__) && !defined(__clang__)
+                #ifdef AVOID_FALLTHROUGH_WARNING
                 __attribute__ ((fallthrough));  /* shut-up -Wimplicit-fallthrough warning in GCC */
                 #endif
             }


### PR DESCRIPTION
Hi.  While trying to make [C-Blosc2](https://github.com/Blosc/c-blosc2) as free of warnings as possible I fixed a fall-through warning in Lizard that only shows up in GCC.  The fix here works for GCC, Clang and MSVC (for a detailed discussion see https://dzone.com/articles/implicit-fallthrough-in-gcc-7).