### PR TITLE
Avoid adding an offset to NULL

### DIFF
--- a/lib/lizard_decompress_lz4.h
+++ b/lib/lizard_decompress_lz4.h
@@ -27,7 +27,7 @@ FORCE_INLINE int Lizard_decompress_LZ4(
     BYTE* cpy = NULL;
     BYTE* oexit = op + targetOutputSize;
     const BYTE* const lowLimit = lowPrefix - dictSize;
-    const BYTE* const dictEnd = (const BYTE*)dictStart + dictSize;
+    const BYTE* const dictEnd = dictStart ? (const BYTE*)dictStart + dictSize : NULL;
 
     const int checkOffset = (dictSize < (int)(LIZARD_DICT_SIZE));
 


### PR DESCRIPTION
On https://github.com/sorbet/sorbet we were seeing ubsan errors with lizard in CI after upgrading to clang-10.0.0.

```
[2021-02-03T18:47:17Z] ==================== Test output for //main/lsp:error_reporter_test:
[2021-02-03T18:47:17Z] external/lizard/lib/lizard_decompress_lz4.h:30:56: runtime error: applying zero offset to null pointer
[2021-02-03T18:47:17Z]     #0 0x1f78c7e  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x1f78c7e)
[2021-02-03T18:47:17Z]     #1 0x1e1f75c  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x1e1f75c)
[2021-02-03T18:47:17Z]     #2 0x1e2b466  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x1e2b466)
[2021-02-03T18:47:17Z]     #3 0x1dc8375  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x1dc8375)
[2021-02-03T18:47:17Z]     #4 0x1402215  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x1402215)
[2021-02-03T18:47:17Z]     #5 0x13f8054  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x13f8054)
[2021-02-03T18:47:17Z]     #6 0x2661bac  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x2661bac)
[2021-02-03T18:47:17Z]     #7 0x2665ef8  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x2665ef8)
[2021-02-03T18:47:17Z]     #8 0x7fbfeeff6b96  (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
[2021-02-03T18:47:17Z]     #9 0x134fbd9  (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/main/lsp/error_reporter_test+0x134fbd9)
```

The fix was to conditionally add the `dictSize` depending on whether `dictStart` was `NULL`.